### PR TITLE
Implement support for tar file format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,28 @@ Archive Kafka data safely to S3.
 
 bifrost is a daemon that connects to Kafka, consumes all topics and
 persists them to S3 for long term storage and analysis. It uses the
-[baldr file format](https://github.com/uswitch/baldr) to store Kafka
-messages. baldr-files are gzipped before they are written to disk.
+[baldr (default)](https://github.com/uswitch/baldr) or
+[tar](http://en.wikipedia.org/wiki/Tar_%28computing%29) file format to
+store Kafka messages. baldr-files are gzipped before they are written to
+disk.
 
 There are other services for persisting messages from Kafka to S3, such
 as [secor](https://github.com/pinterest/secor) from pinterest. The main
 difference between bifrost and these is, that whereas they rely on the
-Hadoop sequence files for storage, bifrost uses the baldr format. This
-means that consumers of the persisted messages do not need to rely on
-often very large implementations of libraries for reading Hadoop
-sequence files. The baldr file format follows a minimal design that
-allows for easy and quick streaming with a very small code-footprint. It
-does not allow for arbitrary indexing.
+Hadoop sequence files for storage, bifrost uses the baldr or tar
+format. This means that consumers of the persisted messages do not need
+to rely on often very large implementations of libraries for reading
+Hadoop sequence files. The baldr file format follows a minimal design
+that allows for easy and quick streaming with a very small
+code-footprint. It does not allow for arbitrary indexing. The tar file
+format has widespread support on *nix platform systems.
 
 ## Usage
 
 bifrost can be run directly from a checkout of the project by using
 leiningen. The app requires some basic configuration, namely ZooKeeper
-configuration to connect to Kafka and AWS credentials to store
-baldr-files on S3. The project contains an example configuration in
+configuration to connect to Kafka and AWS credentials to store files on
+S3. The project contains an example configuration in
 `etc/config.edn.example`.
 
      $ lein run -- --config ./etc/config.edn
@@ -35,9 +38,9 @@ that on the app server.
     $ lein uberjar
     $ java -jar target/*-standalone.jar --config /opt/uswitch/bifrost/etc/config.edn
 
-The Java temp-dir is used for storing baldr-files locally before
-uploading them. Files are removed upon succesful upload and program
-exit. To change the temp-directory, override `java.io.tmpdir`.
+The Java temp-dir is used for storing files locally before uploading
+them. Files are removed upon succesful upload and program exit. To
+change the temp-directory, override `java.io.tmpdir`.
 
 Logging is done through logback. To configure logback, please set
 `logback.configurationFile`. The logback configuration is only respected

--- a/etc/config.example.edn
+++ b/etc/config.example.edn
@@ -14,4 +14,5 @@
  :uploaders-n         4 ; max-number of concurrent threads uploading to S3
  :bucket              "my-bifrost-bucket"
  :riemann-host        nil ; if :riemann-host is set, metrics will be pushed to that host
+ :seq-file-format     :tar ; available sequence file formats are :baldr and :tar
  }

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [clj-kafka "0.2.6-0.8" :exclusions [org.slf4j/slf4j-simple]]
                  [riemann-clojure-client "0.2.9"]
                  [baldr "0.1.1"]
+                 [org.apache.commons/commons-compress "1.9"]
                  [org.pingles/clj-aws-s3 "0.3.10"]
                  [metrics-clojure "1.0.1"]
                  [org.xerial.snappy/snappy-java "1.1.0.1"]

--- a/src/uswitch/bifrost/system.clj
+++ b/src/uswitch/bifrost/system.clj
@@ -28,11 +28,15 @@
 
 (def buffer-size 100)
 
+(def ^:private default-config
+  {:seq-file-format :baldr})
+
 (defn make-system [config]
-  (system-map
-   :metrics-reporter (metrics-reporter config)
+  (let [config (merge default-config config)]
+    (system-map
+     :metrics-reporter (metrics-reporter config)
 
-   :rotated-event-ch (observable-chan "rotated-event-ch" buffer-size)
+     :rotated-event-ch (observable-chan "rotated-event-ch" buffer-size)
 
-   :kafka-system (using (kafka-system config) [:rotated-event-ch])
-   :s3-system    (using (s3-system    config) [:rotated-event-ch])))
+     :kafka-system (using (kafka-system config) [:rotated-event-ch])
+     :s3-system    (using (s3-system    config) [:rotated-event-ch]))))


### PR DESCRIPTION
I have added support for tar files as a sequence format. I like adding the option as it is a lower barrier into using Bifrost, and as tar files have excellent tooling on *nix systems.

There are some cons though:

- The change relies on the Apache Commons Compress project, adding yet another dependency to the binary.
- The codebase has grown. A configuration parameter is now passed through countless calls.

I think the latter point is the most annoying. The call arg lists are waaaaay to long. I wonder if some of the args would scan better moved to records in a more (dare I say) OO like design.